### PR TITLE
fix: add dependabot ignore rules for semver-major provider updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,10 @@ updates:
     directory: "/"
     multi-ecosystem-group: "module"
     patterns: ["*"]
+    ignore:
+      - dependency-name: "hashicorp/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "microsoft/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "azure/*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

- Adds `ignore` stanza to the `terraform` package-ecosystem entry in `.github/dependabot.yml`
- Prevents dependabot from creating PRs for semver-major updates to `hashicorp/*`, `microsoft/*`, and `azure/*` providers
- Aligns this repo's dependabot config with the standard used across all other primitive modules

## Test plan

- [ ] Dependabot configuration is valid YAML
- [ ] CI/workflow checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)